### PR TITLE
argument 1 of class_exists needs to be string. Fixes #6

### DIFF
--- a/src/App/Cli/Example.php
+++ b/src/App/Cli/Example.php
@@ -35,7 +35,7 @@ class Example extends Base {
 		 * @see Requester::isCli()
 		 * @see Bootstrap::__construct
 		 */
-		if ( class_exists( \WP_CLI ) ) {
+		if ( class_exists( '\WP_CLI' ) ) {
 			\WP_CLI::add_command( 'plugin_commandname', [ $this, 'commandExample' ] );
 		}
 	}


### PR DESCRIPTION
This pull request just fixes a typo on /src/App/Cli/Example.php failing WP-Cli.
Check the issue #6 for details.